### PR TITLE
Added multi-line variable support

### DIFF
--- a/lib/node-kit.js
+++ b/lib/node-kit.js
@@ -258,7 +258,9 @@ Kit.prototype._compileToken = function(token) {
     var lineNumber = token.lineNumber;
 
     // First, get the keyword. (Either @import or a variable name)
-    var parts = tokenString.match(/([$@][^\s=:]+)(?:\s*[=:]?\s*(.+))?/);
+    // (And handle variables with multi-line content properly — 
+    // e.g., HTML content that has been formatted over multiple lines.)
+    var parts = tokenString.match(/([$@][^\s=:]+)(?:\s*[=:]?\s*((.|[\r\n])+))?/);
     var keyword = parts[1];
     var predicate = parts[2];
 


### PR DESCRIPTION
Was breaking on multi-line variables (only the first line would be included). This was a problem for properly formatted HTML-content in variables — something I use quite often with partials. Fixed by adding support for newlines in the RegExp (since JS doesn’t have ‘make dot match newlines’ option for RegExps).
