### PR TITLE
Add 'nil' support for unsetting variable(s)

### DIFF
--- a/lib/node-kit.js
+++ b/lib/node-kit.js
@@ -315,7 +315,7 @@ Kit.prototype._compileToken = function(token) {
             throw new Error(format('Line %d of %s: The variable %s is undefined.', lineNumber, filename, keyword));
         }
 
-        this.compiled += value;
+        this.compiled += (value !== 'nil' ? value : '');
     }
 };
 

--- a/test/fixtures/results/variableToNil.html
+++ b/test/fixtures/results/variableToNil.html
@@ -1,0 +1,5 @@
+
+<p class=""> This text is amazing </p>
+
+
+<div class=""> This text is amazing </div>

--- a/test/fixtures/variableToNil.kit
+++ b/test/fixtures/variableToNil.kit
@@ -1,0 +1,7 @@
+<!-- $pClassName = nil -->
+
+<p class="<!--$pClassName-->"> This text is amazing </p>
+
+<!-- $divClassName:nil -->
+
+<div class="<!--$divClassName-->"> This text is amazing </div>

--- a/test/node-kit.test.js
+++ b/test/node-kit.test.js
@@ -84,4 +84,8 @@ describe('Kit', function () {
         errorTest('importsMissing');
     });
 
+    it('shouldn\'t render a nil value for a variable', function () {
+        fixtureTest('variableToNil');
+    });
+
 });


### PR DESCRIPTION
## Usecase

According to Codekit help (https://incident57.com/codekit/help.html#kit) "Nil Variables" is supported, yet by using the command line version and setting a variable to "nil" will output that exact value in the HTML end result.
